### PR TITLE
Add `flow` and `queue` metrics

### DIFF
--- a/main.go
+++ b/main.go
@@ -71,7 +71,7 @@ func (e *Exporter) Collect(ch chan<- prometheus.Metric) {
 }
 
 func (e *Exporter) collectMetrics(stats *Stats, ch chan<- prometheus.Metric) {
-	for _, k := range []string{"jvm", "events", "process", "reloads"} {
+	for _, k := range []string{"jvm", "events", "process", "reloads", "flow", "queue"} {
 		if tree, ok := (*stats)[k]; ok {
 			e.collectTree(k, tree, prometheus.Labels{}, ch)
 		}
@@ -161,7 +161,7 @@ func (e *Exporter) collectPipeline(pipelineName string, data interface{}, ch cha
 		labels["pipeline"] = pipelineName
 	}
 
-	for _, k := range []string{"events", "reloads", "queue", "dead_letter_queue"} {
+	for _, k := range []string{"events", "reloads", "queue", "dead_letter_queue", "flow"} {
 		e.collectTree("pipeline_"+k, stats[k], labels, ch)
 	}
 


### PR DESCRIPTION
We are not currently collecting those metrics from Logstash, which are indicators of the amount of backpressure from Logstash to Filebeat:

```
❯ curl http://localhost:9304/metrics  |grep logstash_flow |grep -v \#
logstash_flow_filter_throughput_current 0.09971
logstash_flow_filter_throughput_last_15_minutes 0.4548
logstash_flow_filter_throughput_last_1_hour 0.6083
logstash_flow_filter_throughput_last_1_minute 0.6995
logstash_flow_filter_throughput_last_5_minutes 0.5047
logstash_flow_filter_throughput_lifetime 0.6334
logstash_flow_input_throughput_current 0.1994
logstash_flow_input_throughput_last_15_minutes 0.7855
logstash_flow_input_throughput_last_1_hour 1.042
logstash_flow_input_throughput_last_1_minute 1.332
logstash_flow_input_throughput_last_5_minutes 0.9144
logstash_flow_input_throughput_lifetime 1.096
logstash_flow_output_throughput_current 0.1994
logstash_flow_output_throughput_last_15_minutes 0.7855
logstash_flow_output_throughput_last_1_hour 1.042
logstash_flow_output_throughput_last_1_minute 1.332
logstash_flow_output_throughput_last_5_minutes 0.9144
logstash_flow_output_throughput_lifetime 1.096
logstash_flow_queue_backpressure_current 0
logstash_flow_queue_backpressure_last_15_minutes 9.448e-05
logstash_flow_queue_backpressure_last_1_hour 0.0001246
logstash_flow_queue_backpressure_last_1_minute 0.0001499
logstash_flow_queue_backpressure_last_5_minutes 9.833e-05
logstash_flow_queue_backpressure_lifetime 0.0003322
logstash_flow_worker_concurrency_current 0.001595
logstash_flow_worker_concurrency_last_15_minutes 0.002336
logstash_flow_worker_concurrency_last_1_hour 0.003179
logstash_flow_worker_concurrency_last_1_minute 0.002865
logstash_flow_worker_concurrency_last_5_minutes 0.002199
logstash_flow_worker_concurrency_lifetime 0.005158

❯ curl http://localhost:9304/metrics  |grep logstash_queue |grep -v \#
logstash_queue_events_count 0
```